### PR TITLE
fix responsive-image bug in firefox < 55 and safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "deneb-ui": "^0.5.2",
     "hammerjs": "^2.0.8",
     "ie-shim": "0.1.0",
-    "intersection-observer": "^0.2.1",
+    "intersection-observer": "^0.3.2",
     "reflect-metadata": "^0.1.9",
     "rxjs": "5.0.2",
     "semantic-ui-less": "^2.2.4",

--- a/src/app/admin/bangumi-detail/bangumi-detail.component.ts
+++ b/src/app/admin/bangumi-detail/bangumi-detail.component.ts
@@ -21,19 +21,34 @@ export class BangumiDetail implements OnInit, OnDestroy {
 
     private _subscription = new Subscription();
     private _toastRef: UIToastRef<UIToastComponent>;
+    private _bangumi = <Bangumi>{};
 
-    bangumi: Bangumi = <Bangumi>{};
+    set bangumi(bangumi: Bangumi) {
+        this._bangumi = bangumi;
+        if (this.bangumi.episodes && this.bangumi.episodes.length > 0) {
+            this.orderedEpisodeList = this.bangumi.episodes.sort((episode1, episode2) => {
+                return episode1.episode_no - episode2.episode_no;
+            });
+        } else {
+            this.orderedEpisodeList = [];
+        }
+    }
+
+    get bangumi(): Bangumi {
+        return this._bangumi;
+    }
 
     isLoading: boolean = false;
 
-    get orderedEpisodeList(): Episode[] {
-        if (this.bangumi.episodes && this.bangumi.episodes.length > 0) {
-            return this.bangumi.episodes.sort((episode1, episode2) => {
-                return episode1.episode_no - episode2.episode_no
-            });
-        }
-        return [];
-    }
+    // get orderedEpisodeList(): Episode[] {
+    //     if (this.bangumi.episodes && this.bangumi.episodes.length > 0) {
+    //         return this.bangumi.episodes.sort((episode1, episode2) => {
+    //             return episode1.episode_no - episode2.episode_no;
+    //         });
+    //     }
+    //     return [];
+    // }
+    orderedEpisodeList: Episode[] = [];
 
     constructor(private _route: ActivatedRoute,
                 private _router: Router,

--- a/src/app/home/default/default.html
+++ b/src/app/home/default/default.html
@@ -9,7 +9,9 @@
     <div class="ui five doubling cards" *ngIf="onAirBangumi">
         <div class="card bangumi-card" *ngFor="let bangumi of onAirBangumi">
             <a class="image" [routerLink]="['/bangumi', bangumi.id]">
-                <responsive-image [src]="bangumi.cover" [size]="{width: '100%', ratio: 1.405152224824}" [background]="bangumi.cover_color"></responsive-image>
+                <responsive-image [src]="bangumi.cover"
+                                  [size]="{width: '100%', ratio: 1.405152224824}"
+                                  [background]="bangumi.cover_color"></responsive-image>
             </a>
             <div *ngIf="bangumi.favorite_status" class="ui ribbon label"
                  [ngClass]="{

--- a/src/app/responsive-image/responsive-image.directive.ts
+++ b/src/app/responsive-image/responsive-image.directive.ts
@@ -51,7 +51,6 @@ export class ResponsiveImage implements OnInit, OnDestroy {
     constructor(private _element: ElementRef,
                 private _responsiveService: ResponsiveService,
                 private _changeDetector: ChangeDetectorRef) {
-        console.log('responsive image: #' + (Math.random() * 1000));
     }
 
     ngOnInit(): void {
@@ -85,7 +84,6 @@ export class ResponsiveImage implements OnInit, OnDestroy {
         this.observableStub = {
             target: this._element.nativeElement,
             callback: (rect: ClientRect) => {
-                console.log(rect);
                 if (!this.dimension || this.dimension.width !== 'auto') {
                     this._width = rect.width;
                 } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,9 +2119,9 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-intersection-observer@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.2.1.tgz#cb55175f4eebef6436d957a7d1774d39a9248e5e"
+intersection-observer@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.3.2.tgz#9ed30021c08b29e9e8565c8d512ed84515727433"
 
 invert-kv@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
fix #51 by upgrading the intersection-observer polyfill, this will also fix the responsive-image bug in safari.
For more information see: https://github.com/WICG/IntersectionObserver/issues/216

also fix a bug which may cause firefox freeze when opening bangumi detail page(admin/bangumi/<id>) in development mode.