### PR TITLE
add multiple video_file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.8.0
+
+Add multiple video file support, video_file dialog in admin will show all the editable field.
+But only label and download_url should be edit when adding a new video file. To enable multiple video file playback in
+PlayEpisode component, a dropdown picker (or label list when in small screen) is added. note that the backend must be upgraded to 2.7.8 and above to filter
+out unfinished video_file to avoid exception.
+
 ## 2.7.2
 
 - remove new-year icon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deneb",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Web client for Albireo",
   "author": "Nyasoft<about@nya.io>",
   "homepage": "https://github.com/lordfriend/Deneb",

--- a/src/app/admin/bangumi-detail/video-file-modal/video-file-modal.html
+++ b/src/app/admin/bangumi-detail/video-file-modal/video-file-modal.html
@@ -12,6 +12,30 @@
                 <label>id</label>
                 <input type="text" formControlName="id" readonly>
             </div>
+            <div class="two fields">
+                <div class="field">
+                    <label>file_name</label>
+                    <input type="text" formControlName="file_name">
+                </div>
+                <div class="field">
+                    <label>label</label>
+                    <input type="text" formControlName="label">
+                </div>
+            </div>
+            <div class="three fields">
+                <div class="field">
+                    <label>resolution_w</label>
+                    <input type="text" formControlName="resolution_w" readonly>
+                </div>
+                <div class="field">
+                    <label>resolution_h</label>
+                    <input type="text" formControlName="resolution_h" readonly>
+                </div>
+                <div class="field">
+                    <label>duration</label>
+                    <input type="text" formControlName="duration" readonly>
+                </div>
+            </div>
             <div class="field">
                 <label>download_url</label>
                 <input type="text" placeholder="magnet或torrent文件的url" formControlName="download_url">

--- a/src/app/home/play-episode/play-episode.component.ts
+++ b/src/app/home/play-episode/play-episode.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, PipeTransform, Pipe } from '@angular/core';
 import { Episode, Bangumi } from "../../entity";
 import { HomeService, HomeChild } from "../home.service";
 import { ActivatedRoute, Router } from '@angular/router';
@@ -7,6 +7,7 @@ import { Title } from '@angular/platform-browser';
 import { WatchService } from '../watch.service';
 import { WatchProgress } from '../../entity/watch-progress';
 import { VideoPlayer } from '../../video-player/video-player.component';
+import { VideoFile } from '../../entity/video-file';
 
 export const MIN_WATCHED_PERCENTAGE = 0.95;
 
@@ -42,6 +43,8 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy {
 
     isBangumiReady: boolean;
 
+    currentVideoFile: VideoFile;
+
     @ViewChild(VideoPlayer) videoPlayer: VideoPlayer;
 
     constructor(homeService: HomeService,
@@ -52,6 +55,16 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy {
         super(homeService);
     }
 
+    onVideoFileChnage(videoFile: VideoFile):void {
+        let loc = window.location;
+        if (!!loc.search) {
+            let params = new URLSearchParams(loc.search);
+            params.set('video_id', videoFile.id);
+            loc.search = `?${params.toString()}`;
+        } else {
+            loc.search = `?video_id=${videoFile.id}`;
+        }
+    }
 
     focusVideoPlayer(event: Event) {
         let target = event.target as HTMLElement;
@@ -78,6 +91,12 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy {
     }
 
     ngOnInit(): any {
+        let searchStr = window.location.search;
+        let videoFileId = null;
+        if (!!searchStr) {
+            let params = new URLSearchParams(searchStr);
+            videoFileId = params.get('video_id');
+        }
         this.routeParamsSubscription = this.route.params
             .flatMap((params) => {
                 let episode_id = params['episode_id'];
@@ -85,6 +104,15 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy {
             })
             .flatMap((episode: Episode) => {
                 this.episode = episode;
+                if (videoFileId) {
+                    this.currentVideoFile = this.episode.video_files
+                        .filter(videoFile => videoFile.status === VideoFile.STATUS_DOWNLOADED)
+                        .find(videoFile => videoFile.id === videoFileId);
+                }
+                if (!this.currentVideoFile) {
+                    this.currentVideoFile = this.episode.video_files
+                        .find(videoFile => videoFile.status === VideoFile.STATUS_DOWNLOADED);
+                }
                 return this.homeService.bangumi_datail(episode.bangumi_id);
             })
             .subscribe(

--- a/src/app/home/play-episode/play-episode.html
+++ b/src/app/home/play-episode/play-episode.html
@@ -3,7 +3,7 @@
 </div>
 <div class="theater-backdrop" *ngIf="episode" (click)="focusVideoPlayer($event)">
     <video-player class="player-width player-height"
-                  [videoFile]="episode.video_files[0]"
+                  [videoFile]="currentVideoFile"
                   [startPosition]="episode.watch_progress?.last_watch_position"
                   [thumbnail]="episode.thumbnail"
                   [bangumiName]="episode.bangumi.name_cn || episode.bangumi.name"
@@ -16,59 +16,80 @@
                   (onDurationUpdate)="onDurationUpdate($event)"
                   (onPlayNextEpisode)="onPlayNext($event)"></video-player>
 </div>
-<div class="ui container episode-info-container" *ngIf="episode">
-<h3 class=episode-title>
-    <span class="bangumi-name">{{episode.bangumi.name_cn}}</span>
-    <span class="episode-no">{{episode.episode_no}}</span>
-    <span class="episode-name-cn">{{episode.name_cn}}</span>
-</h3>
-<div class="ui divider">
+<div class="ui container video-file-picker-container" *ngIf="!!episode">
+    <div class="video-file-picker dropdown-picker">
+        <span>选择视频源：</span>
+        <div class="ui inline dropdown" uiDropdown="click" [stopPropagation]="true">
+            <div class="text">{{currentVideoFile.label || currentVideoFile.file_name}}</div>
+            <i class="dropdown icon"></i>
+            <div class="menu">
+                <div class="item" *ngFor="let videoFile of episode.video_files" (click)="onVideoFileChnage(videoFile)">{{videoFile.label || videoFile.file_name}}</div>
+            </div>
+        </div>
+    </div>
+    <div class="video-file-picker label-picker">
+        <span>选择视频源：</span>
+        <a class="ui label"
+           *ngFor="let videoFile of episode.video_files"
+           [ngClass]="{'blue': videoFile.id === currentVideoFile.id}"
+           (click)="onVideoFileChnage(videoFile)">
+            {{videoFile.label || videoFile.file_name}}
+        </a>
+    </div>
 </div>
-<div class="bangumi-info">
-    <div class="bangumi-cover">
-        <responsive-image [src]="episode.bangumi.cover_image.url"
-                          [size]="{
+<div class="ui container episode-info-container" *ngIf="!!episode">
+    <h3 class=episode-title>
+        <span class="bangumi-name">{{episode.bangumi.name_cn}}</span>
+        <span class="episode-no">{{episode.episode_no}}</span>
+        <span class="episode-name-cn">{{episode.name_cn}}</span>
+    </h3>
+    <div class="ui divider">
+    </div>
+    <div class="bangumi-info">
+        <div class="bangumi-cover">
+            <responsive-image [src]="episode.bangumi.cover_image.url"
+                              [size]="{
                             width: '100%',
                             height: 'auto',
                             originalWidth: episode.bangumi.cover_image.width,
                             originalHeight: episode.bangumi.cover_image.height}"
-                          [background]="episode.bangumi.cover_image.dominant_color"></responsive-image>
-    </div>
-    <div class="bangumi-basic-info">
-        <h2 class="bangumi-title name-cn">
-            <a [routerLink]="['/bangumi', episode.bangumi_id]">
-                {{episode.bangumi.name_cn}}
-            </a>
-            <a class="external-link" [href]="'https://bgm.tv/subject/' + episode.bangumi.bgm_id" target="_blank"
-               title="在bgm.tv页面查看">
-                <i class="bgm-emo-47 bgm-link-icon"></i>
-            </a>
-        </h2>
-        <h4 class="bangumi-title name">{{episode.bangumi.name}}</h4>
-        <favorite-chooser *ngIf="isBangumiReady" [bangumi]="episode.bangumi"></favorite-chooser>
-        <div class="summary">
-            {{episode.bangumi.summary}}
+                              [background]="episode.bangumi.cover_image.dominant_color"></responsive-image>
         </div>
-        <h4>
-            各话列表
-        </h4>
-        <div class="episode-list-loading-wrapper" *ngIf="!episode.bangumi.episodes">
-            <div class="ui active inverted dimmer">
-                <div class="ui medium loader"></div>
+        <div class="bangumi-basic-info">
+            <h2 class="bangumi-title name-cn">
+                <a [routerLink]="['/bangumi', episode.bangumi_id]">
+                    {{episode.bangumi.name_cn}}
+                </a>
+                <a class="external-link" [href]="'https://bgm.tv/subject/' + episode.bangumi.bgm_id" target="_blank"
+                   title="在bgm.tv页面查看">
+                    <i class="bgm-emo-47 bgm-link-icon"></i>
+                </a>
+            </h2>
+            <h4 class="bangumi-title name">{{episode.bangumi.name}}</h4>
+            <favorite-chooser *ngIf="isBangumiReady" [bangumi]="episode.bangumi"></favorite-chooser>
+            <div class="summary">
+                {{episode.bangumi.summary}}
+            </div>
+            <h4>
+                各话列表
+            </h4>
+            <div class="episode-list-loading-wrapper" *ngIf="!episode.bangumi.episodes">
+                <div class="ui active inverted dimmer">
+                    <div class="ui medium loader"></div>
+                </div>
+            </div>
+            <div class="episode-list ui eight column doubling grid" *ngIf="episode.bangumi.episodes">
+                <div class="column" *ngFor="let eps of episode.bangumi.episodes">
+                    <a class="ui segment episode-link" *ngIf="eps.status===2" [routerLink]="['/play', eps.id]">
+                        {{eps.episode_no}}
+                    </a>
+                    <a class="ui disabled segment episode-link" *ngIf="eps.status!==2">
+                        {{eps.episode_no}}
+                    </a>
+                </div>
             </div>
         </div>
-        <div class="episode-list ui eight column doubling grid" *ngIf="episode.bangumi.episodes">
-            <div class="column" *ngFor="let eps of episode.bangumi.episodes">
-                <a class="ui segment episode-link" *ngIf="eps.status===2" [routerLink]="['/play', eps.id]">
-                    {{eps.episode_no}}
-                </a>
-                <a class="ui disabled segment episode-link" *ngIf="eps.status!==2">
-                    {{eps.episode_no}}
-                </a>
-            </div>
-        </div>
     </div>
-</div>
 </div>
 
 

--- a/src/app/home/play-episode/play-episode.less
+++ b/src/app/home/play-episode/play-episode.less
@@ -10,6 +10,31 @@
   background-color: #000;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
+
+.video-file-picker-container {
+  position: relative;
+  .video-file-picker {
+    padding: 0.5em 0;
+  }
+  .dropdown-picker {
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+  .label-picker {
+    display: none;
+  }
+  @media (max-width: 767px) {
+    .dropdown-picker {
+      display: none;
+    }
+    .label-picker {
+      display: block;
+    }
+  }
+}
+
 .episode-info-container {
   margin-top: 2rem;
 


### PR DESCRIPTION
Add multiple video file support, video_file dialog in admin will show all the editable field.
But only label and download_url should be edit when adding a new video file. To enable multiple video file playback in
PlayEpisode component, a dropdown picker (or label list when in small screen) is added. note that the backend must be upgraded to 2.7.8 and above to filter
out unfinished video_file to avoid exception.
![screenshot from 2018-01-12 14-15-41](https://user-images.githubusercontent.com/1235614/34862114-8aca0f44-f7a3-11e7-8f17-8765708ff903.png)
![screenshot from 2018-01-12 14-14-14](https://user-images.githubusercontent.com/1235614/34862116-8afcb44e-f7a3-11e7-9ea3-af22bb04a1fa.png)

