### PR TITLE
3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.4
+
+
+
+## 3.0.3
+
+Fix bug which may cause crash in bangumi charactor info
+
 ## 3.0.2
 
 Fix crash in bangumi detail when some information is null (staff, crt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 3.0.4
 
-
+- fix bug in favorite-chooser, some operation may occasionally make EditReviewDialog got stuck. Solve this issue by replacing ApplicationRef#tick() to NgZone#run(). Currently not know why.
+- Add a box shadow in feedback dialog.
+- Move synchronize invoke out of EditReviewDialog.
+- After update favorite, a get favorite request will be sent.
 
 ## 3.0.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deneb",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "description": "Web client for Albireo",
   "author": "Nyasoft<about@nya.io>",
   "homepage": "https://github.com/lordfriend/Deneb",

--- a/src/app/home/favorite-chooser/favorite-chooser.component.ts
+++ b/src/app/home/favorite-chooser/favorite-chooser.component.ts
@@ -8,7 +8,6 @@ import { UIDialog, UIToast, UIToastComponent, UIToastRef } from 'deneb-ui';
 import { Subscription } from 'rxjs/Subscription';
 import { AuthInfo, ChromeExtensionService, LOGON_STATUS } from '../../browser-extension/chrome-extension.service';
 import { SynchronizeService } from './synchronize.service';
-import { WatchProgress } from '../../entity/watch-progress';
 
 @Component({
     selector: 'favorite-chooser',
@@ -33,6 +32,7 @@ export class FavoriteChooser implements OnInit, OnDestroy {
     isExtensionEnabled: boolean;
     authInfo: AuthInfo;
     isBgmLogin = LOGON_STATUS.UNSURE;
+
     get syncEnabled(): boolean {
         return this.isExtensionEnabled && !!this.authInfo && this.isBgmLogin === LOGON_STATUS.TRUE;
     }
@@ -58,22 +58,42 @@ export class FavoriteChooser implements OnInit, OnDestroy {
 
     onEditReview() {
         const dialogRef = this._dialog.open(EditReviewDialogComponent, {backdrop: true, stickyDialog: true});
-        if (this.userFavoriteInfo) {
-            dialogRef.componentInstance.comment = this.userFavoriteInfo.comment;
-            dialogRef.componentInstance.rating = this.userFavoriteInfo.rating;
-            dialogRef.componentInstance.tags = Array.isArray(this.userFavoriteInfo.tags) ? this.userFavoriteInfo.tags.join(' ') : '';
-        }
+        dialogRef.componentInstance.comment = this.userFavoriteInfo ? this.userFavoriteInfo.comment : '';
+        dialogRef.componentInstance.rating = this.userFavoriteInfo ? this.userFavoriteInfo.rating : 0;
+        dialogRef.componentInstance.tags = this.userFavoriteInfo ? (Array.isArray(this.userFavoriteInfo.tags) ? this.userFavoriteInfo.tags.join(' ') : '') : '';
         dialogRef.componentInstance.bangumi = this.bangumi;
         this._subscription.add(dialogRef.afterClosed()
             .filter(result => !!result)
+            .flatMap((result) => {
+                this.isOnSynchronizing = true;
+                /**
+                 * export interface FavoriteStatus {
+                 *      interest: number;
+                 *      rating: number;
+                 *      tags: string;
+                 *      comment: string;
+                 * }
+                 */
+                return this._synchronize.updateFavorite(this.bangumi, result);
+            })
+            .flatMap(() => {
+                return this._chromeExtensionService.invokeBangumiMethod('favoriteStatus', [this.bangumi.bgm_id]);
+            })
             .subscribe((result) => {
-                if (!this.userFavoriteInfo) {
-                    this.userFavoriteInfo = {};
+                console.log(result);
+                this.isOnSynchronizing = false;
+                this.userFavoriteInfo = result;
+                this.bangumi.favorite_status = result.status.id;
+            }, (error) => {
+                console.log(error);
+                if (error && error.status === 404) {
+                    this.bangumi.favorite_status = 0;
+                    this.userFavoriteInfo = null;
                 }
-                this.userFavoriteInfo.rating = result.rating;
-                this.userFavoriteInfo.comment = result.comment;
-                this.bangumi.favorite_status = result.interest;
-            }));
+                this.isOnSynchronizing = false;
+                this._toastRef.show('更新失败');
+            })
+        );
     }
 
     deleteFavorite() {
@@ -81,10 +101,13 @@ export class FavoriteChooser implements OnInit, OnDestroy {
         if (this.syncEnabled) {
             this._subscription.add(
                 this._synchronize.deleteFavorite(this.bangumi)
+                    .do(() => {
+                        this.homeService.changeFavorite();
+                    })
                     .subscribe(() => {
                         this.isOnSynchronizing = false;
-                        this.homeService.changeFavorite();
-                        this.bangumi.favorite_status = undefined;
+                        this.bangumi.favorite_status = 0;
+                        this.userFavoriteInfo = null;
                         this._toastRef.show('已删除收藏');
                     }, () => {
                         this.isOnSynchronizing = false;
@@ -151,7 +174,7 @@ export class FavoriteChooser implements OnInit, OnDestroy {
                     if (this.isBgmLogin === LOGON_STATUS.TRUE && !!this.authInfo) {
                         this.toggleButtonText = '收藏/评价';
                     } else {
-                        this.toggleButtonText = '收藏 (未关联Bangumi无法同步)';
+                        this.toggleButtonText = '收藏';
                     }
                 })
                 .filter(isLogin => isLogin === LOGON_STATUS.TRUE)

--- a/src/app/home/play-episode/feedback/feedback.less
+++ b/src/app/home/play-episode/feedback/feedback.less
@@ -23,6 +23,9 @@
   border-radius: 4px;
   background-color: #fff;
   overflow: hidden;
+  -webkit-box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
+  box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
 }
 
 .ui.form {

--- a/src/app/home/rating/edit-review-dialog/edit-review-dialog.component.ts
+++ b/src/app/home/rating/edit-review-dialog/edit-review-dialog.component.ts
@@ -85,28 +85,12 @@ export class EditReviewDialogComponent implements OnInit, OnDestroy {
          *      comment: string;
          * }
          */
-        this._subscription.add(
-            this._synchronizeService.updateFavorite(
-                this.bangumi,
-                {
-                    interest: this.favorite_status,
-                    rating: this.rating,
-                    tags: this.tags,
-                    comment: comment
-                })
-                .subscribe(() => {
-                    this.isSaving = false;
-                    this._dialogRef.close({
-                        interset: this.favorite_status,
-                        rating: this.rating,
-                        comment: comment
-                    });
-                }, (error) => {
-                    this.isSaving = false;
-                    console.log(error);
-                    this._toastRef.show('更新失败');
-                })
-        );
+        this._dialogRef.close({
+            interest: this.favorite_status,
+            rating: this.rating,
+            tags: this.tags,
+            comment: comment
+        });
     }
 
     cancel(): void {
@@ -114,6 +98,7 @@ export class EditReviewDialogComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
+        console.log(this.bangumi, this.rating, this.comment, this.tags);
         this.favorite_status = this.bangumi.favorite_status;
         this.reviewForm = this._fb.group({
             comment: ['', Validators.maxLength(200)]
@@ -128,6 +113,7 @@ export class EditReviewDialogComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
+        console.log('destroyed');
         this._subscription.unsubscribe();
     }
 }


### PR DESCRIPTION
- fix a bug in favorite-chooser, some operation may occasionally make EditReviewDialog got stuck. Solve this issue by replacing ApplicationRef#tick() to NgZone#run(). Currently not know why.
- Add a box shadow in feedback dialog.
- Move synchronize invoke out of EditReviewDialog.
- After update favorite, a get favorite request will be sent.