### PR TITLE
3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.7
+
+Fix bug in web-hook management editor which cause shared_secret cannot be saved.
+
 ## 3.0.6
 
 - Fix the issue in favorite-choose when operating in play-episode page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deneb",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Web client for Albireo",
   "author": "Nyasoft<about@nya.io>",
   "homepage": "https://github.com/lordfriend/Deneb",

--- a/src/app/admin/web-hook/edit-web-hook/edit-web-hook.component.ts
+++ b/src/app/admin/web-hook/edit-web-hook/edit-web-hook.component.ts
@@ -94,7 +94,7 @@ export class EditWebHookComponent implements OnInit, OnDestroy {
         if (result.permission_email) {
             result.permissions.push(WebHook.PERMISSION_EMAIL);
         }
-        if (this.webHook) {
+        if (this.webHook && !result.shared_secret) {
             result.shared_secret = undefined;
         }
         this._dialogRef.close({result: result});


### PR DESCRIPTION
Fix bug in web-hook management editor which cause shared_secret cannot be saved.