### PR TITLE
Change check favorite api parsing to fix an issue

### DIFF
--- a/src/app/home/home.service.ts
+++ b/src/app/home/home.service.ts
@@ -71,8 +71,9 @@ export class HomeService extends BaseService {
     checkFavorite(bangumi_id: string) {
         this._watchService.check_favorite(bangumi_id)
             .subscribe((data) => {
-                this.favoriteChecked.emit({bangumi_id: bangumi_id, check_time: data.data});
-                console.log(`bangumi ${bangumi_id} checked`);
+                if (data.status != 0) {
+                    this.favoriteChecked.emit({bangumi_id: bangumi_id, check_time: data.data});
+                }
             }, (error) => {
                 console.log(error);
             });


### PR DESCRIPTION
home service: change api parsing to fix issue, details provided below.

We should check the "status" value of the api response. If it equals 0, which means the queried bangumi is not favorited by the user, we should do nothing.