### PR TITLE
4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.0.6
+
+- fix a bug in PlayEpisode, when the video_id exists on the route parameter. the currentVideoFile may be null. which
+ cause the onLoadAndPlay get a null VideoFile.
+
 ## 4.0.5
 
 fix a bug in favorite-manager.service, result user cannot change favorite when without using browser extension.

--- a/src/app/home/play-episode/play-episode.component.ts
+++ b/src/app/home/play-episode/play-episode.component.ts
@@ -98,12 +98,6 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy, AfterVi
     }
 
     ngOnInit(): void {
-        let searchStr = window.location.search;
-        let videoFileId = null;
-        if (!!searchStr) {
-            let params = new URLSearchParams(searchStr);
-            videoFileId = params.get('video_id');
-        }
         this._subscription.add(
             this._videoPlayerService.onPlayNextEpisode
                 .subscribe(episodeId => {
@@ -124,6 +118,12 @@ export class PlayEpisode extends HomeChild implements OnInit, OnDestroy, AfterVi
                     this.homeService.checkFavorite(episode.bangumi_id);
                 }),
                 switchMap((episode: Episode) => {
+                    let searchStr = window.location.search;
+                    let videoFileId = null;
+                    if (!!searchStr) {
+                        let params = new URLSearchParams(searchStr);
+                        videoFileId = params.get('video_id');
+                    }
                     this.episode = episode;
                     if (videoFileId) {
                         this.currentVideoFile = this.episode.video_files


### PR DESCRIPTION
fix bug when the URL of the current route has video_id, navigate to any other episode will crash the video player.